### PR TITLE
Make generated npm links lowercased

### DIFF
--- a/src/components/ohno.js
+++ b/src/components/ohno.js
@@ -8,7 +8,7 @@ export default ({ data, value }) => (
       <a
         target="_blank"
         rel="noopener noreferrer"
-        href={`https://www.npmjs.com/package/${value}`}
+        href={`https://www.npmjs.com/package/${value.toLowerCase()}`}
       >
         "{data.description}"
       </a>


### PR DESCRIPTION
Not doing that will redirect some queries to npm's 404 page.

So, the Ohno component will be rendered but will point to a broken link